### PR TITLE
Update CORBA reference.

### DIFF
--- a/_bibliography/rpc.bib
+++ b/_bibliography/rpc.bib
@@ -59,12 +59,11 @@
   year={2009}
 }
 
-@book{corba,
-  title={CORBA 3 fundamentals and programming},
-  author={Siegel, Jon and Ph. D.},
-  volume={2},
-  year={2000},
-  publisher={John Wiley \& Sons New York, NY, USA:}
+@article{corba,
+  title={The common object request broker: architecture and specification},
+  author={DEC, HP and HyperDesk, NCR and others},
+  journal={Object Management Group},
+  year={1991}
 }
 
 @misc{grpc,

--- a/_bibliography/rpc.bib
+++ b/_bibliography/rpc.bib
@@ -61,8 +61,8 @@
 
 @article{corba,
   title={The common object request broker: architecture and specification},
-  author={DEC, HP and HyperDesk, NCR and others},
-  journal={Object Management Group},
+  author={Object Management Group},
+  journal={OMG Document Number 91.12.1},
   year={1991}
 }
 

--- a/_bibliography/rpc.bib
+++ b/_bibliography/rpc.bib
@@ -60,7 +60,7 @@
 }
 
 @article{corba,
-  title={The common object request broker: architecture and specification},
+  title={The Common Object Request Broker: Architecture and Specification},
   author={Object Management Group},
   journal={OMG Document Number 91.12.1},
   year={1991}


### PR DESCRIPTION
Cite the 1991 initial CORBA 1.0 specification from the Object Management Group.